### PR TITLE
Resolve type assertion

### DIFF
--- a/analysis/analyse.go
+++ b/analysis/analyse.go
@@ -805,7 +805,7 @@ func findErrorCodesFromIdentTaint(c *context, visitedIdents map[*ast.Object]stru
 			newCodes := findErrorCodesInCallExpression(c, expr, function)
 			result = Union(result, newCodes)
 		default:
-			panic(fmt.Sprintf("destruct assignment should only originate from a call expression: type %T", expr))
+			panic(fmt.Sprintf("destructuring assignment is currently only supported from a call expression: found one in an expression of type %T", expr))
 		}
 	}
 

--- a/analysis/analyse_test.go
+++ b/analysis/analyse_test.go
@@ -77,6 +77,21 @@ func TestNotImplemented(t *testing.T) {
 				`dereference_assignment/assign.go:18:1: unexpected diagnostic: function "DereferenceAssignment2" has a mismatch of declared and actual error codes: unused codes: [other-error]`,
 			},
 		},
+		{
+			pattern: "type_assertion",
+			expected: []string{
+				`type_assertion/assert.go:6:1: unexpected diagnostic: function "TypeAssertionMethod" has a mismatch of declared and actual error codes: unused codes: [interface-error]`,
+				`type_assertion/assert.go:8:9: unexpected diagnostic: type assertion is not supported in error code analysis`,
+				`type_assertion/assert.go:14:1: unexpected diagnostic: function "TypeAssertionInterface" has a mismatch of declared and actual error codes: unused codes: [empty-interface-error]`,
+				`type_assertion/assert.go:15:9: unexpected diagnostic: type assertion is not supported in error code analysis`,
+				`type_assertion/assert.go:21:1: unexpected diagnostic: function "TypeAssertion" has a mismatch of declared and actual error codes: unused codes: [standard-error]`,
+				`type_assertion/assert.go:22:9: unexpected diagnostic: type assertion is not supported in error code analysis`,
+				`type_assertion/assert.go:47:1: unexpected diagnostic: function "TypeAssertionSwitch" has a mismatch of declared and actual error codes: unused codes: [maybe-error]`,
+				`type_assertion/assert.go:49:14: unexpected diagnostic: type assertion switch is not supported in error code analysis`,
+				`type_assertion/assert.go:63:1: unexpected diagnostic: function "TypeAssertionSwitchFromNonError" has a mismatch of declared and actual error codes: unused codes: [empty-interface-error]`,
+				`type_assertion/assert.go:65:16: unexpected diagnostic: type assertion switch is not supported in error code analysis`,
+			},
+		},
 	} {
 		t.Run(testcase.pattern, func(t *testing.T) {
 			testcase := testcase

--- a/analysis/taint_spread.go
+++ b/analysis/taint_spread.go
@@ -10,7 +10,7 @@ import (
 type (
 	taintSpreadResult struct {
 		expressions        []ast.Expr             // expressions that represent the taint, or nil
-		destructAssignment []*taintSpreadDestruct // taint originating from destructirung assignments, or nil
+		destructAssignment []*taintSpreadDestruct // taint originating from destructing assignments, or nil
 		identOutOfScope    []*ast.Ident           // every used ident that was not defined in functio scope, or nil
 	}
 

--- a/analysis/taint_spread.go
+++ b/analysis/taint_spread.go
@@ -10,7 +10,7 @@ import (
 type (
 	taintSpreadResult struct {
 		expressions        []ast.Expr             // expressions that represent the taint, or nil
-		destructAssignment []*taintSpreadDestruct // taint originating from destructing assignments, or nil
+		destructAssignment []*taintSpreadDestruct // taint originating from destructuring assignments, or nil
 		identOutOfScope    []*ast.Ident           // every used ident that was not defined in functio scope, or nil
 	}
 

--- a/analysis/testdata/src/type_assertion/assert.go
+++ b/analysis/testdata/src/type_assertion/assert.go
@@ -1,0 +1,75 @@
+package typeassertion
+
+// Errors:
+//
+//  - interface-error --
+func TypeAssertionMethod() *Error { // want TypeAssertionMethod:"ErrorCodes: interface-error"
+	value := Receiver{}.Method()
+	return value.(*Error)
+}
+
+// Errors:
+//
+//  - empty-interface-error --
+func TypeAssertionInterface() error { // want TypeAssertionInterface:"ErrorCodes: empty-interface-error"
+	return EmptyInterfaceError().(error)
+}
+
+// Errors:
+//
+// - standard-error --
+func TypeAssertion() *Error { // want TypeAssertion:"ErrorCodes: standard-error"
+	return StandardError().(*Error)
+}
+
+func TypeAssertionNoCodes() *Error { // want `function "TypeAssertionNoCodes" is exported, but does not declare any error codes`
+	return StandardError().(*Error)
+}
+
+// Errors:
+//
+// - maybe-error -- sometimes
+// - standard-error -- never but the analyser doesn't know that
+func TypeAssertionMultipleTypes() error { // want TypeAssertionMultipleTypes:"ErrorCodes: maybe-error standard-error"
+	if err := MaybeError(); err != nil {
+		if err, ok := err.(ErrorInterface); ok {
+			return err
+		}
+		return StandardError()
+	}
+	return nil
+}
+
+// Errors:
+//
+// - maybe-error -- sometimes
+// - standard-error -- never but the analyser doesn't know that
+func TypeAssertionSwitch() error { // want TypeAssertionSwitch:"ErrorCodes: maybe-error standard-error"
+	err := MaybeError()
+	switch x := err.(type) {
+	case *Error:
+		return x
+	case nil:
+		return nil
+	default:
+		return StandardError()
+	}
+}
+
+// Errors:
+//
+//   - empty-interface-error -- always
+//   - standard-error -- never
+func TypeAssertionSwitchFromNonError() error { // want TypeAssertionSwitchFromNonError:"ErrorCodes: empty-interface-error standard-error"
+	iface := EmptyInterfaceError()
+	switch err := iface.(type) {
+	case *Error:
+		return err
+	case ErrorInterface:
+		return err
+	case nil:
+		return nil
+	default:
+		return StandardError()
+	}
+}

--- a/analysis/testdata/src/type_assertion/definitions.go
+++ b/analysis/testdata/src/type_assertion/definitions.go
@@ -1,0 +1,51 @@
+package typeassertion
+
+import (
+	"math/rand"
+)
+
+type Receiver struct{}
+
+// Errors:
+//
+//    - interface-error -- always
+func (Receiver) Method() error { // want Method:"ErrorCodes: interface-error"
+	return &Error{"interface-error"}
+}
+
+// Errors:
+//
+//    - standard-error -- always
+func StandardError() error { // want StandardError:"ErrorCodes: standard-error"
+	return &Error{"standard-error"}
+}
+
+// EmptyInterfaceError isn't detected by serum-analyzer as an error return type
+func EmptyInterfaceError() interface{} {
+	return &Error{"empty-interface-error"}
+}
+
+// Errors:
+//
+//   - maybe-error -- sometimes
+func MaybeError() error { // want MaybeError:"ErrorCodes: maybe-error"
+	if rand.Float64() < 0.5 {
+		return &Error{"maybe-error"}
+	}
+	return nil
+}
+
+type Error struct { // want Error:`ErrorType{Field:{Name:"TheCode", Position:0}, Codes:}`
+	TheCode string
+}
+
+func (e *Error) Code() string               { return e.TheCode }
+func (e *Error) Message() string            { return e.TheCode }
+func (e *Error) Details() map[string]string { return nil }
+func (e *Error) Cause() error               { return nil }
+func (e *Error) Error() string              { return e.Message() }
+
+type ErrorInterface interface {
+	error
+	Code() string
+}


### PR DESCRIPTION
This gives an error instead of a panic for the demo code base in #2. (#5 go1.18+ fix seems to have resolved the panic as well)

Now it returns a bunch of errors that seem much more reasonable, if not any more functional. There's a good chance that the codes from the old identity could be assigned to the new identity and just ignore the type assertion but I'm not really sure how to do that.
```
$ go-serum-analyzer -strict ./...
/home/cjb/repos/misc/go-demo-app-with-serum/cli/cli.go:107:1: function "Do" is exported, but does not declare any error codes
/home/cjb/repos/misc/go-demo-app-with-serum/jobbers/terror/terror.go:23:6: unsupported: tracking error codes across type assertions
/home/cjb/repos/misc/go-demo-app-with-serum/jobbers/terror/terror.go:21:1: function "InducePanic" has a mismatch of declared and actual error codes: unused codes: [jobber-error-natch]
```