### PR TITLE
Implemention of extracting errors from error type conversions

### DIFF
--- a/analysis/analyse.go
+++ b/analysis/analyse.go
@@ -640,6 +640,14 @@ func findErrorCodesFromFunctionCall(c *context, startingFunc *funcDefinition, ca
 		return Union(result, fact.Codes)
 	}
 
+	// Get codes that originate from call expressions that are actually conversions to an error type.
+	if callExpr != nil && callee == nil {
+		conversionCodes := extractErrorCodesFromTypeConversion(pass, callExpr)
+		if len(conversionCodes) > 0 {
+			return Union(result, conversionCodes)
+		}
+	}
+
 	calledFuncDef := funcDefinition{nil, nil}
 
 	switch calledExpression := astutil.Unparen(calledFunction).(type) {

--- a/analysis/extract_error_code.go
+++ b/analysis/extract_error_code.go
@@ -113,6 +113,21 @@ func findFieldInitExpression(pass *analysis.Pass, constructExpr ast.Expr, field 
 	return nil
 }
 
+// extractErrorCodesFromTypeConversion checks if the given call expression is a conversion to an error type and
+// if that's the case, returns the error codes originating from that conversion.
+func extractErrorCodesFromTypeConversion(pass *analysis.Pass, callExpr *ast.CallExpr) CodeSet {
+	funType := pass.TypesInfo.TypeOf(callExpr.Fun)
+	errorType, err := getErrorTypeForError(pass, funType)
+
+	if errorType == nil || err != nil {
+		return nil
+	}
+
+	return SliceToSet(errorType.Codes)
+}
+
+// extractErrorCodeFromConstructorCall checks if the given callee is an error constructor and
+// then extracts the error code from the correct call argument.
 func extractErrorCodeFromConstructorCall(pass *analysis.Pass, startingFunc *funcDefinition, reportRange analysis.Range, callee types.Object, callExpr *ast.CallExpr) (string, bool) {
 	var fact ErrorConstructor
 	if callee == nil || !pass.ImportObjectFact(callee, &fact) {

--- a/analysis/tag_error_types.go
+++ b/analysis/tag_error_types.go
@@ -114,7 +114,6 @@ func tagErrorType(pass *analysis.Pass, lookup *funcLookup, err types.Type, spec 
 func getErrorTypeForError(pass *analysis.Pass, err types.Type) (*ErrorType, error) {
 	namedErr := getNamedType(err)
 	if namedErr == nil {
-		logf("err type: %#v\n", err)
 		return nil, fmt.Errorf("passed invalid err type to getErrorTypeForError")
 	}
 


### PR DESCRIPTION
Found this in @janispeyer's fork and it looks useful? It makes more test cases pass anyway. I vote we merge it.